### PR TITLE
Replace long with int64_t to work on Macs

### DIFF
--- a/src/stubs/bindings.ml
+++ b/src/stubs/bindings.ml
@@ -105,7 +105,7 @@ module C (F : Cstubs.FOREIGN) = struct
     let parameter =
       foreign
         "parameter"
-        (Builder.t @-> int64_t @-> int @-> int @-> ptr long @-> string @-> returning t)
+        (Builder.t @-> int64_t @-> int @-> int @-> ptr int64_t @-> string @-> returning t)
 
     (* Binary functions. *)
     let add = foreign "op_add" (t @-> t @-> returning t)

--- a/src/wrapper/wrappers.ml
+++ b/src/wrapper/wrappers.ml
@@ -258,7 +258,7 @@ module Op = struct
   let constant literal ~builder = W.Op.constant_literal builder literal |> of_ptr ~builder
 
   let parameter name ~id ~ty ~dims ~builder =
-    let dims = carray_map dims ~ctype:Ctypes.long ~f:Signed.Long.of_int in
+    let dims = carray_map dims ~ctype:Ctypes.int64_t ~f:Int64.of_int in
     let t =
       W.Op.parameter
         builder

--- a/src/wrapper/xla_stubs.cpp
+++ b/src/wrapper/xla_stubs.cpp
@@ -200,7 +200,7 @@ xla_op constant_literal(const xla_builder b, const literal l) {
 FOR_EACH_NATIVE_TYPE(CONST_OP_R01)
 #undef CONST_OP_R01
 
-xla_op parameter(const xla_builder b, int64_t id, int pr_type, int dsize, const long int *ds, const char *name) {
+xla_op parameter(const xla_builder b, int64_t id, int pr_type, int dsize, const int64_t *ds, const char *name) {
   BEGIN_PROTECT_OP
   bool has_negative_dim = false;
   for (int i = 0; i < dsize; ++i) {
@@ -222,9 +222,9 @@ xla_op parameter(const xla_builder b, int64_t id, int pr_type, int dsize, const 
         dynamic.push_back(false);
       }
     }
-    shape = ShapeUtil::MakeShape((PrimitiveType)pr_type, absl::Span<const long int>(bounds.data(), bounds.size()), dynamic);
+    shape = ShapeUtil::MakeShape((PrimitiveType)pr_type, absl::Span<const int64_t>(bounds.data(), bounds.size()), dynamic);
   } else {
-    shape = ShapeUtil::MakeShape((PrimitiveType)pr_type, absl::Span<const long int>(ds, dsize));
+    shape = ShapeUtil::MakeShape((PrimitiveType)pr_type, absl::Span<const int64_t>(ds, dsize));
   }
   return new XlaOp(Parameter(b, id, shape, std::string(name)));
   END_PROTECT_OP_B(b)
@@ -601,7 +601,7 @@ xla_op op_rng_uniform(const xla_op arg1, const xla_op arg2, int pr_type, int dsi
   BEGIN_PROTECT_OP
   auto shape = ShapeUtil::MakeShape(
       (PrimitiveType)pr_type,
-      absl::Span<const long int>(ds, dsize)
+      absl::Span<const int64_t>(ds, dsize)
   );
   return new XlaOp(RngUniform(*arg1, *arg2, shape));
   END_PROTECT_OP(arg1)
@@ -611,7 +611,7 @@ xla_op op_rng_normal(const xla_op arg1, const xla_op arg2, int pr_type, int dsiz
   BEGIN_PROTECT_OP
   auto shape = ShapeUtil::MakeShape(
       (PrimitiveType)pr_type,
-      absl::Span<const long int>(ds, dsize)
+      absl::Span<const int64_t>(ds, dsize)
   );
   return new XlaOp(RngNormal(*arg1, *arg2, shape));
   END_PROTECT_OP(arg1)
@@ -751,7 +751,7 @@ xla_op op_iota(const xla_builder b, int pr_type, size_t dsize, const int64_t* ds
   BEGIN_PROTECT_OP
   auto shape = ShapeUtil::MakeShape(
       (PrimitiveType)pr_type,
-      absl::Span<const long int>(ds, dsize)
+      absl::Span<const int64_t>(ds, dsize)
   );
   return new XlaOp(Iota(b, shape, increasing_dim));
   END_PROTECT_OP_B(b)

--- a/src/wrapper/xla_stubs.h
+++ b/src/wrapper/xla_stubs.h
@@ -76,7 +76,7 @@ xla_builder xla_builder_create(const char*);
 void xla_builder_free(xla_builder);
 
 xla_op constant_literal(const xla_builder, const literal);
-xla_op parameter(const xla_builder, int64_t, int, int, const long int *, const char*);
+xla_op parameter(const xla_builder, int64_t, int, int, const int64_t *, const char*);
 
 // Ops
 xla_op op_add(const xla_op, const xla_op);


### PR DESCRIPTION
Previously, when I tried to run `example/basics.exe` on Mac laptops, I got compilation issues like the following

![image](https://user-images.githubusercontent.com/25846260/235329619-cb39e3d6-78d5-489c-8fdf-3e54148fce97.png)

This PR replaces `long` with `int64_t` to avoid this issue. I haven't had a chance to test this on a linux machine, but I believe `int64_t` should have the same meaning across platforms? 

After these changes, I get:

![image](https://user-images.githubusercontent.com/25846260/235329268-0abc3e11-dd04-45b3-bcb4-4af3f6e14b8c.png)

with `dune exec examples/basics.exe`

