### PR TITLE
Expose HloModule::ToString()

### DIFF
--- a/src/stubs/bindings.ml
+++ b/src/stubs/bindings.ml
@@ -305,6 +305,9 @@ module C (F : Cstubs.FOREIGN) = struct
     let computation =
       foreign "xla_computation_from_hlo_module_proto" (t @-> returning Computation0.t)
 
+    let to_string =
+      foreign "hlo_module_proto_to_string" (t @-> ptr (ptr char) @-> returning Status.t)
+
     let parse_and_return_unverified_module =
       foreign
         "hlo_module_proto_parse_and_return_unverified_module"

--- a/src/wrapper/wrappers.ml
+++ b/src/wrapper/wrappers.ml
@@ -187,9 +187,9 @@ module Literal = struct
     t
 
   let of_bigarray_bytes
-    ~(src : (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t)
-    ~ty
-    ~dims
+        ~(src : (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t)
+        ~ty
+        ~dims
     =
     let size_in_bytes = Bigarray.Genarray.size_in_bytes src in
     let expected_size_in_bytes =
@@ -470,13 +470,13 @@ module Op = struct
     t
 
   let gather
-    t
-    ~start_indices
-    ~offset_dims
-    ~collapsed_slice_dims
-    ~start_index_map
-    ~set_index_vector_dim
-    ~slice_sizes
+        t
+        ~start_indices
+        ~offset_dims
+        ~collapsed_slice_dims
+        ~start_index_map
+        ~set_index_vector_dim
+        ~slice_sizes
     =
     let offset_dims = carray_i64 offset_dims in
     let collapsed_slice_dims = carray_i64 collapsed_slice_dims in
@@ -634,6 +634,12 @@ module HloModuleProto = struct
     ptr
 
   let computation t = W.HloModuleProto.computation t |> computation_of_ptr
+
+  let to_string t =
+    let ptr = Ctypes.(allocate (ptr char) (from_voidp char null)) in
+    let status = W.HloModuleProto.to_string t ptr in
+    Status.ok_exn status;
+    Ctypes.( !@ ) ptr |> Ctypes_std_views.string_of_char_ptr
 
   let parse_text data =
     let ptr = Ctypes.(allocate_n (ptr W.HloModuleProto.struct_) ~count:1) in
@@ -807,10 +813,10 @@ module PjRtBuffer = struct
     Ctypes.( !@ ) ptr |> of_ptr ~client:device.client
 
   let of_bigarray_bytes
-    ~(src : (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t)
-    ~ty
-    ~dims
-    ~device
+        ~(src : (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Genarray.t)
+        ~ty
+        ~dims
+        ~device
     =
     let size_in_bytes = Bigarray.Genarray.size_in_bytes src in
     let expected_size_in_bytes =

--- a/src/wrapper/wrappers.mli
+++ b/src/wrapper/wrappers.mli
@@ -196,6 +196,7 @@ module HloModuleProto : sig
   type t
 
   val computation : t -> Op.computation
+  val to_string : t -> string
   val parse_proto : string -> binary:bool -> t
   val parse_text : string -> t
 end

--- a/src/wrapper/xla_stubs.cpp
+++ b/src/wrapper/xla_stubs.cpp
@@ -1033,6 +1033,15 @@ char *status_error_message(status s) {
   return strdup(s->error_message().c_str());
 }
 
+status hlo_module_proto_to_string(hlo_module_proto p, char **output) {
+  ASSIGN_OR_RETURN_STATUS(config, HloModule::CreateModuleConfigFromProto(
+                                  *p, {}));
+  ASSIGN_OR_RETURN_STATUS(
+      hmp, HloModule::CreateFromProto(*p, config));
+  *output = strdup(hmp->ToString().c_str());
+  return nullptr;
+}
+
 status hlo_module_proto_parse_and_return_unverified_module(
     const char *data, size_t len, hlo_module_proto *output) {
   ASSIGN_OR_RETURN_STATUS(

--- a/src/wrapper/xla_stubs.h
+++ b/src/wrapper/xla_stubs.h
@@ -225,6 +225,8 @@ literal literal_make_tuple(const literal *, size_t);
 literal literal_make_tuple_owned(const literal *, size_t);
 void literal_free(literal);
 
+status hlo_module_proto_to_string(const hlo_module_proto, char **);
+
 status hlo_module_proto_parse_and_return_unverified_module(const char *, size_t,
                                                            hlo_module_proto *);
 status hlo_module_proto_parse_proto(const char *, size_t, bool,

--- a/tests/basics.ml
+++ b/tests/basics.ml
@@ -30,31 +30,79 @@ let eval ~args ~f =
   let literal = Buffer.to_literal_sync buffers.(0).(0) in
   let ba = Literal.to_bigarray literal ~kind:Bigarray.float32 in
   let dims = Bigarray.Genarray.dims ba in
-  Stdio.print_s [%message (dims : int array) (ba : bigarray)]
+  Stdio.print_s
+    [%message
+      (dims : int array)
+        (ba : bigarray)
+        ~hmp:(Hlo_module_proto.to_string (Computation.proto computation))]
 
 let%expect_test _ =
   set_log_level ();
   eval ~args:[||] ~f:(fun ~builder ->
     let r0_f32 = Xla.Op.r0_f32 ~builder in
     Xla.Op.add (r0_f32 39.) (r0_f32 3.));
-  [%expect {|
-        ((dims ()) (ba 42))
-  |}];
+  [%expect
+    {|
+    ((dims ()) (ba 42)
+     (hmp
+       "HloModule mybuilder.4, entry_computation_layout={()->f32[]}\
+      \n\
+      \nENTRY %mybuilder.4 () -> f32[] {\
+      \n  %constant.2 = f32[] constant(39)\
+      \n  %constant.1 = f32[] constant(3)\
+      \n  ROOT %add.3 = f32[] add(f32[] %constant.2, f32[] %constant.1)\
+      \n}\
+      \n\
+      \n"))
+    |}];
   eval ~args:[||] ~f:(fun ~builder ->
     let r0_f32 = Xla.Op.r0_f32 ~builder in
     Xla.Op.sub (r0_f32 39.) (r0_f32 3.));
-  [%expect {|
-        ((dims ()) (ba 36))
-  |}];
+  [%expect
+    {|
+    ((dims ()) (ba 36)
+     (hmp
+       "HloModule mybuilder.4, entry_computation_layout={()->f32[]}\
+      \n\
+      \nENTRY %mybuilder.4 () -> f32[] {\
+      \n  %constant.2 = f32[] constant(39)\
+      \n  %constant.1 = f32[] constant(3)\
+      \n  ROOT %subtract.3 = f32[] subtract(f32[] %constant.2, f32[] %constant.1)\
+      \n}\
+      \n\
+      \n"))
+    |}];
   eval ~args:[||] ~f:(fun ~builder ->
     let r0_f32 = Xla.Op.r0_f32 ~builder in
     Xla.Op.mul (r0_f32 39.) (r0_f32 3.));
-  [%expect {|
-        ((dims ()) (ba 117))
-  |}];
+  [%expect
+    {|
+    ((dims ()) (ba 117)
+     (hmp
+       "HloModule mybuilder.4, entry_computation_layout={()->f32[]}\
+      \n\
+      \nENTRY %mybuilder.4 () -> f32[] {\
+      \n  %constant.2 = f32[] constant(39)\
+      \n  %constant.1 = f32[] constant(3)\
+      \n  ROOT %multiply.3 = f32[] multiply(f32[] %constant.2, f32[] %constant.1)\
+      \n}\
+      \n\
+      \n"))
+    |}];
   eval ~args:[||] ~f:(fun ~builder ->
     let r0_f32 = Xla.Op.r0_f32 ~builder in
     Xla.Op.div (r0_f32 39.) (r0_f32 3.));
-  [%expect {|
-        ((dims ()) (ba 13))
-      |}]
+  [%expect
+    {|
+    ((dims ()) (ba 13)
+     (hmp
+       "HloModule mybuilder.4, entry_computation_layout={()->f32[]}\
+      \n\
+      \nENTRY %mybuilder.4 () -> f32[] {\
+      \n  %constant.2 = f32[] constant(39)\
+      \n  %constant.1 = f32[] constant(3)\
+      \n  ROOT %divide.3 = f32[] divide(f32[] %constant.2, f32[] %constant.1)\
+      \n}\
+      \n\
+      \n"))
+    |}]


### PR DESCRIPTION
Exposes `HloModule::ToString()`, mostly for use in debugging constructed computations.

https://github.com/mt-caret/fox/pull/1 has some example expect test output as well.